### PR TITLE
Fix webbrowser opening for MacOS

### DIFF
--- a/plugins/thread.py
+++ b/plugins/thread.py
@@ -219,7 +219,7 @@ class ProcessThread(Thread):
 
         os.rename(temp_file, os.path.join(temp_dir, gerberArchiveName))
 
-        webbrowser.open(temp_dir)
+        webbrowser.open("file://%s" % (temp_dir))
         # webbrowser.open(urls['redirect'])
         self.report(-1)
 


### PR DESCRIPTION
On MacOS I was not able to have the web browser opening the temporary directory without
this change.

Please note that it will open the Finder - not the web browser - in spite of the
name webbrowser.

Please check if it solves #2 and if there are not regressions on non-macos platforms (Linux, Windows, ...)