### PR TITLE
Fix `UnicodeEncodeError` during csv file writing

### DIFF
--- a/plugins/thread.py
+++ b/plugins/thread.py
@@ -98,7 +98,7 @@ class ProcessThread(Thread):
             footprint_designators[footprint.GetReference()] += 1
         bom_designators = footprint_designators.copy()
 
-        with open((os.path.join(temp_dir, designatorsFileName)), 'w') as f:
+        with open((os.path.join(temp_dir, designatorsFileName)), 'w', encoding='utf-8') as f:
             for key, value in footprint_designators.items():
                 f.write('%s:%s\n' % (key, value))
 
@@ -152,7 +152,7 @@ class ProcessThread(Thread):
                     'LCSC Part #': self.getMpnFromFootprint(footprint),
                 })
 
-        with open((os.path.join(temp_dir, placementFileName)), 'w', newline='') as outfile:
+        with open((os.path.join(temp_dir, placementFileName)), 'w', newline='', encoding='utf-8') as outfile:
             header = True
             csv_writer = csv.writer(outfile)
 
@@ -168,7 +168,7 @@ class ProcessThread(Thread):
 
         # generate BOM file
         self.report(60)
-        with open((os.path.join(temp_dir, bomFileName)), 'w', newline='') as outfile:
+        with open((os.path.join(temp_dir, bomFileName)), 'w', newline='', encoding='utf-8') as outfile:
             header = True
             csv_writer = csv.writer(outfile)
 


### PR DESCRIPTION
For some reasons (maybe because I have a fr_FR.UTF-8 install) I was not able to
run this plugin without running into this error:
```
Traceback (most recent call last):
  File "com_github_bennymeg_JLC-Plugin-for-KiCad/thread.py", line 183, in run
    csv_writer.writerow(component.values())
UnicodeEncodeError: 'ascii' codec can't encode character '\xb5' in position 13: ordinal not in range(128)
```

A small fix is to open the file with UTF-8 encoding ; which solves this issue.

I added the same encoding fix to all 3 text files creation just to guard against
this issue coming in the future.