### PR TITLE
Fixes for KiCad 7 nightly compatibility

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -27,7 +27,6 @@ class ProcessManager:
         plot_options.SetScale(1)
         plot_options.SetMirror(False)
         plot_options.SetUseGerberAttributes(True)
-        plot_options.SetExcludeEdgeLayer(True)
         plot_options.SetUseGerberProtelExtensions(False)
         plot_options.SetUseAuxOrigin(True)
         plot_options.SetSubtractMaskFromSilk(False)
@@ -107,7 +106,7 @@ class ProcessManager:
                     'Designator': "{}{}{}".format(footprint.GetReference(), "" if unique_id == "" else "_", unique_id),
                     'Mid X': (footprint.GetPosition()[0] - self.board.GetDesignSettings().GetAuxOrigin()[0]) / 1000000.0,
                     'Mid Y': (footprint.GetPosition()[1] - self.board.GetDesignSettings().GetAuxOrigin()[1]) * -1.0 / 1000000.0,
-                    'Rotation': footprint.GetOrientation() / 10.0,
+                    'Rotation': footprint.GetOrientation().AsDegrees(),
                     'Layer': layer,
                 })
 

--- a/plugins/process.py
+++ b/plugins/process.py
@@ -27,6 +27,8 @@ class ProcessManager:
         plot_options.SetScale(1)
         plot_options.SetMirror(False)
         plot_options.SetUseGerberAttributes(True)
+        if hasattr(plot_options, "SetExcludeEdgeLayer"):
+            plot_options.SetExcludeEdgeLayer(True)
         plot_options.SetUseGerberProtelExtensions(False)
         plot_options.SetUseAuxOrigin(True)
         plot_options.SetSubtractMaskFromSilk(False)
@@ -106,7 +108,7 @@ class ProcessManager:
                     'Designator': "{}{}{}".format(footprint.GetReference(), "" if unique_id == "" else "_", unique_id),
                     'Mid X': (footprint.GetPosition()[0] - self.board.GetDesignSettings().GetAuxOrigin()[0]) / 1000000.0,
                     'Mid Y': (footprint.GetPosition()[1] - self.board.GetDesignSettings().GetAuxOrigin()[1]) * -1.0 / 1000000.0,
-                    'Rotation': footprint.GetOrientation().AsDegrees(),
+                    'Rotation': footprint.GetOrientation().AsDegrees() if hasattr(footprint.GetOrientation(), 'AsDegrees') else footprint.GetOrientation() / 10.0,
                     'Layer': layer,
                 })
 


### PR DESCRIPTION
* edge layers are not excluded in v7
* use orientation as degrees

Probably it makes sense to maintain this as a separate branch for now.