### PR TITLE
Add new symbol field support for easyeda2kicad.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Add an 'LCSC Part #'* field with the LCSC component part number to the symbol's 
 _The fields will be query in the order denoted above._
 
 #### Fallback Fields*:
-| 'lcsc#' | 'LCSC' | 'JLC' | 'MPN' | 'Mpn' | 'mpn' |
-| --- | --- | --- | --- | --- | --- |
+| 'JLC Part' | 'LCSC Part' | 'lcsc#' | 'LCSC' | 'JLC' | 'MPN' | 'Mpn' | 'mpn' |
+| --- | --- | --- | --- | --- | --- | --- | --- |
 
 _The fields will be query in the order denoted above._
 

--- a/plugins/process.py
+++ b/plugins/process.py
@@ -249,7 +249,7 @@ class ProcessManager:
     def _get_mpn_from_footprint(self, footprint: str):
         ''''Get the MPN/LCSC stock code from standard symbol fields.'''
         keys = ['LCSC Part #', 'JLCPCB Part #']
-        fallback_keys = ['LCSC', 'JLC', 'MPN', 'Mpn', 'mpn']
+        fallback_keys = ['LCSC Part', 'JLC Part', 'LCSC', 'JLC', 'MPN', 'Mpn', 'mpn']
 
         for key in keys:
             if footprint.HasProperty(key):


### PR DESCRIPTION
Hiya!

I use **[uPesy/easyeda2kicad.py](https://github.com/uPesy/easyeda2kicad.py)** to download and convert footprints, symbols, and 3D models from JLCPCB/LCSC and noticed that the field that gets populated from that tool was just ever so slightly different from what Fabrication Toolkit looks for, so I've added that field to make that workflow even easier!

I've been doing a find-and-replace for now, but having the Fabrication Toolkit magically handle things would make that flow so much smoother.

Here's the field that gets set in `easyeda2kicad.py`: 

https://github.com/uPesy/easyeda2kicad.py/blob/92088a460fddaa6d266b28be507c863f5635e8c6/easyeda2kicad/kicad/parameters_kicad_symbol.py#L305

Thanks for the awesome tool!