### PR TITLE
Change encoding of output files to UTF-8 with BOM

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -132,7 +132,7 @@ class ProcessManager:
         bom_designators = footprint_designators.copy()
 
         if len(footprint_designators.items()) > 0:
-            with open((os.path.join(temp_dir, designatorsFileName)), 'w', encoding='utf-8') as f:
+            with open((os.path.join(temp_dir, designatorsFileName)), 'w', encoding='utf-8-sig') as f:
                 for key, value in footprint_designators.items():
                     f.write('%s:%s\n' % (key, value))
 
@@ -211,7 +211,7 @@ class ProcessManager:
                     })
 
         if len(self.components) > 0:
-            with open((os.path.join(temp_dir, placementFileName)), 'w', newline='', encoding='utf-8') as outfile:
+            with open((os.path.join(temp_dir, placementFileName)), 'w', newline='', encoding='utf-8-sig') as outfile:
                 csv_writer = csv.writer(outfile)
                 # writing headers of CSV file
                 csv_writer.writerow(self.components[0].keys())
@@ -223,7 +223,7 @@ class ProcessManager:
 
     def generate_bom(self, temp_dir):
         if len(self.bom) > 0:
-            with open((os.path.join(temp_dir, bomFileName)), 'w', newline='', encoding='utf-8') as outfile:
+            with open((os.path.join(temp_dir, bomFileName)), 'w', newline='', encoding='utf-8-sig') as outfile:
                 csv_writer = csv.writer(outfile)
                 # writing headers of CSV file
                 csv_writer.writerow(self.bom[0].keys())


### PR DESCRIPTION
Previously, the encoding of output files was UTF-8. However, this resulted in characters such as 'μ' and 'Ω' being garbled when the file was submitted. Therefore, the encoding of the output file was changed to UTF-8 with BOM.