### PR TITLE
Don't merge similar components with different LCSC part numbers

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -194,7 +194,10 @@ class ProcessManager:
                 # merge similar parts into single entry
                 insert = True
                 for component in self.bom:
-                    if component['Footprint'] == self._normalize_footprint_name(footprint_name) and component['Value'].upper() == footprint.GetValue().upper():
+                    same_footprint = component['Footprint'] == self._normalize_footprint_name(footprint_name)
+                    same_value     = component['Value'].upper() == footprint.GetValue().upper()
+                    same_lcsc      = component['LCSC Part #'] == self._get_mpn_from_footprint(footprint)
+                    if same_footprint and same_value and same_lcsc:
                         component['Designator'] += ", " + "{}{}{}".format(footprint.GetReference(), "" if unique_id == "" else "_", unique_id)
                         component['Quantity'] += 1
                         insert = False


### PR DESCRIPTION
This fix seems to work to keep almost-similar parts separate.

Closes #45