### PR TITLE
Fix rotation offset field name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Select 'Exclude from position files' or 'Exclude from BOM' in the footprint's fa
 <img src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/blob/master/assets/fabrication.png?raw=true" height=505>
 
 ### Offset Component Rotation
-The rotation of components in KiCad Footprints does not always match the orientation in the JLC library because KiCad and JLC PCB used different variation of the same standard. Most of the rotations may be corrected by the `rotations.cf` definitions. To the exception cases: add an 'JLC Rotation Offset' field with an counter-clockwise orientation offset in degrees to correct this.
+The rotation of components in KiCad Footprints does not always match the orientation in the JLC library because KiCad and JLC PCB used different variation of the same standard. Most of the rotations may be corrected by the `rotations.cf` definitions. To the exception cases: add an 'JLCPCB Rotation Offset' field with an counter-clockwise orientation offset in degrees to correct this.
 
 <img src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/blob/master/assets/rotation-jlc.png?raw=true" height=164>
 


### PR DESCRIPTION
The name of the field doesn't match the value [the code actually looks for](https://github.com/bennymeg/JLC-Plugin-for-KiCad/blob/4a59fb0672f798ef9646803f915b3ed3bf244e96/plugins/process.py#L272).  The name of the field is correct elsewhere in the document.