### PR TITLE
feat: add layer override

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ _The fields will be queried in the order denoted above._
 
 _The fields will be queried in the order denoted above._
 
+### ⑤ Override Component Layer
+Some footprints may have it's actual footprint defined on the B.Cu. In these instances you can override mount side with this field.
+
+Values can be `top` or `bottom`.
+
+#### Primary Fields*:
+        | 'JLCPCB Side Override' |
+        | --- |
+
+_The fields will be queried in the order denoted above._
+
+#### Fallback Fields*:
+        | 'JlcSideOverride' | 'JLCSideOverride' |
+        | --- | --- |
+
+_The fields will be queried in the order denoted above._
+
 ## Author
 
 Benny Megidish

--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ Some footprints may have it's actual footprint defined on the B.Cu. In these ins
 Values can be `top` or `bottom`.
 
 #### Primary Fields*:
-        | 'JLCPCB Side Override' |
+        | 'JLCPCB Layer Override' |
         | --- |
 
 _The fields will be queried in the order denoted above._
 
 #### Fallback Fields*:
-        | 'JlcSideOverride' | 'JLCSideOverride' |
+        | 'JlcLayerOverride' | 'JLCLayerOverride' |
         | --- | --- |
 
 _The fields will be queried in the order denoted above._


### PR DESCRIPTION
Add `JLCPCB Layer Override` `JlcLayerOverride` and `JLCLayerOverride`. These can take `top` and `bottom` values.

This will enable the use of footprints that are placed on one side, but ha actual mounting on the other side (such as hot swaps for MX switches).