### PR TITLE
Bottom side rotates still not quite right

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -176,9 +176,9 @@ class ProcessManager:
                 pos_offset = ( pos_offset[0] * rcos - pos_offset[1] * rsin, pos_offset[0] * rsin + pos_offset[1] * rcos )
                 mid_x, mid_y = tuple(map(sum,zip((mid_x, mid_y), pos_offset)))
 
-                # JLC expect 'Rotation' to be 'as viewed from above component', so bottom needs inverting.
-                if layer == 'bottom' and rotation != 0:
-                    rotation = 360.0 - rotation
+                # JLC expect 'Rotation' to be 'as viewed from above component', so bottom needs inverting, and ends up 180 degrees out as well
+                if layer == 'bottom':
+                    rotation = (540.0 - rotation) % 360.0
                                 
                 self.components.append({
                     'Designator': designator,


### PR DESCRIPTION
Inverting around 360 degrees looked fine for angles, even 45 degrees and 10 degrees and so on, but turns out it actually needs inverting around 180 degrees else your diodes are all backwards. Arrrg. Sorry about that.

Screen shots of some diodes, all done with no JLCPCB Rotation Offset set, comparing view on JLCPCB with 3D view from KiCad.

<img width="509" alt="Screenshot 2023-06-21 at 11 06 38" src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/996983/935b2c17-6a3c-46bb-80b2-011e871389c3">
<img width="487" alt="Screenshot 2023-06-21 at 11 06 42" src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/996983/e6e7fb1b-7ee5-4df8-a6ac-b69faefaa6e0">
<img width="410" alt="Screenshot 2023-06-21 at 11 06 48" src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/996983/f86abc0e-f0fa-4104-ba86-91586f63144e">
<img width="398" alt="Screenshot 2023-06-21 at 11 06 51" src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/996983/e2552bc8-64cd-4022-948d-33478f8eba20">
