### PR TITLE
Update process.py for V Cuts

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -86,6 +86,8 @@ class ProcessManager:
         if hasattr(plot_options, "SetExcludeEdgeLayer"):
             plot_options.SetExcludeEdgeLayer(True)
 
+# This includes User_1 with Edge_Cuts to allow V Cuts to be defined as User_1 layer and added so JLC accept it
+# It seems making a separate file just confuses them and they want it in the Edge Cuts file, but that would upset KiCad
         for layer_info in plotPlan:
             if self.board.IsLayerEnabled(layer_info[1]):
                 plot_controller.SetLayer(layer_info[1])
@@ -93,7 +95,11 @@ class ProcessManager:
                     layer_info[0],
                     pcbnew.PLOT_FORMAT_GERBER,
                     layer_info[2])
-                plot_controller.PlotLayer()
+                seq = pcbnew.LSEQ()
+                seq.push_back(layer_info[1])
+                if layer_info[1] == pcbnew.Edge_Cuts :
+                    seq.push_back(pcbnew.User_1)
+                plot_controller.PlotLayers(seq)
 
         plot_controller.ClosePlot()
 


### PR DESCRIPTION
Adds User_1 layer to `Edge_Cuts` file.
It seems JLCPCB want V cuts in the file as Edge Cuts.
So simply make `User_1` a V Cuts layer.

Alternative would be for config for plotPlan to take array of layers to include, not just one later, but my python is not that good.