### PR TITLE
Add limit of parts in BOM rows

### DIFF
--- a/plugins/config.py
+++ b/plugins/config.py
@@ -8,6 +8,7 @@ placementFileName = 'positions.csv'
 bomFileName = 'bom.csv'
 gerberArchiveName = 'gerbers.zip'
 outputFolder = 'production'
+bomRowLimit = 30
 
 plotPlan = [
     ("F.Cu", pcbnew.F_Cu, "Top Layer"),

--- a/plugins/process.py
+++ b/plugins/process.py
@@ -228,7 +228,7 @@ class ProcessManager:
                     same_value = component['Value'].upper() == footprint.GetValue().upper()
                     same_lcsc = component['LCSC Part #'] == self._get_mpn_from_footprint(footprint)
 
-                    if same_footprint and same_value and same_lcsc:
+                    if same_footprint and same_value and same_lcsc and component['Quantity'] < 30:
                         component['Designator'] += ", " + "{}{}{}".format(footprint.GetReference(), "" if unique_id == "" else "_", unique_id)
                         component['Quantity'] += 1
                         insert = False

--- a/plugins/process.py
+++ b/plugins/process.py
@@ -228,7 +228,7 @@ class ProcessManager:
                     same_value = component['Value'].upper() == footprint.GetValue().upper()
                     same_lcsc = component['LCSC Part #'] == self._get_mpn_from_footprint(footprint)
 
-                    if same_footprint and same_value and same_lcsc and component['Quantity'] < 30:
+                    if same_footprint and same_value and same_lcsc and component['Quantity'] < bomRowLimit:
                         component['Designator'] += ", " + "{}{}{}".format(footprint.GetReference(), "" if unique_id == "" else "_", unique_id)
                         component['Quantity'] += 1
                         insert = False


### PR DESCRIPTION
The number of components that are merged into the same row in the BOM file is limited. If there are too many you'll get an "Internal Server Error" when JLCPCB is processing it. 

Their support told me 20 parts per row is the limit but I've tested with 50 and it works, so I split the difference and set it to 30 here. I guess the 20 was only a suggestion :)