### PR TITLE
Add Top and Bottom override on footprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ _The fields will be queried in the order denoted above._
 
 _The fields will be queried in the order denoted above._
 
+### ⑤ Override Component Layer
+Some footprints may have their components defined on the opposite layer to there actual footprints. In these instances you can override mount side by using this field.
+
+Values can be `top`, `bottom`, `t` or `b`.
+
+#### Primary Fields*:
+        | 'JLCPCB Layer Override' |
+        | --- |
+
+_The fields will be queried in the order denoted above._
+
+#### Fallback Fields*:
+        | 'JlcLayerOverride' | 'JLCLayerOverride' |
+        | --- | --- |
+
+_The fields will be queried in the order denoted above._
+
+
+
 ## Author
 
 Benny Megidish

--- a/plugins/process.py
+++ b/plugins/process.py
@@ -307,11 +307,10 @@ class ProcessManager:
                 temp_layer = footprint.GetProperty(key)
                 if (temp_layer[0] == 'b' or temp_layer[0] == 'B'):
                     layer = "bottom"
+                    break
                 elif (temp_layer[0] == 't' or temp_layer[0] == 'T'):
                     layer = "top"
-                else:
-                    continue
-                break
+                    break
 
         return layer
 

--- a/plugins/process.py
+++ b/plugins/process.py
@@ -168,11 +168,11 @@ class ProcessManager:
 
             layer = self._get_top_or_bottom_side_override_from_footprint(footprint)
 
-            #mount_type = {
-            #    0: 'smt',
-            #    1: 'tht',
-            #    2: 'smt'
-            #}.get(footprint.GetAttributes())
+            # mount_type = {
+            #     0: 'smt',
+            #     1: 'tht',
+            #     2: 'smt'
+            # }.get(footprint.GetAttributes())
 
             skip_footprint = exclude_dnp and (footprint.HasProperty('dnp') or footprint.GetValue().upper() == 'DNP')
 


### PR DESCRIPTION
### What is the problem?
Some footprints can be "double-sided" but in reality once broken into individual parts may need to be strictly on one. An example of a footprint that is used for the top, but a component on the bottom is Kaihl V2 Hotswap key where the bus bar is mounted through the bottom and faces the top.

Currently, there is no way to produce a placement file that accounts for, therefor manual editing of the positions file needs to be done to correct the side.

### How does this PR fix this?
By implementing a layer override function, similar to what is already done for rotation and position, we can override the kicad footprint and instead have the positions file reflect the expected output that JLCPCB is expecting.

To apply an override open the schematic, then click on a symbol and add the following field `'JLCPCB Layer Override'` followed by either `top` or `bottom`.

### What testing has been done?
- Tested without any changes, footprint was on the wrong side
- Tested after changes with valid values  (expect the layer to swap to either top or bottom)
  - [x] `t` 
  - [x]  `T`
  - [x]  `top`
  - [x]  `TOP`
  - [x]  `b`
  - [x]  `B`
  - [x]  `bottom`
  - [x]  `BOTTOM`
- Tested with a few invalid values (expect no changes to the default layer)
  - [x] i
  - [x] ` 
- Validated that output on JLC website reflected said change
- Validate that offsets are still correctly being applied after the layer swap.

### Before 
![Untitled](https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/50710252/ff567110-9370-4b3d-be63-3576609efd1d)

### After (Not offset)
![Untitled](https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/50710252/afec42a7-e046-4675-85e5-5194677030bb)
![Untitled2](https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/50710252/1eabc4aa-8691-4de8-af0e-fad8e1ca9b1c)

### After (Post offset)
![after_offset2](https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/50710252/b71573fc-57ab-41f3-9548-1aef5cae077b)
![after_offset](https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/50710252/4b26b0b8-1e56-4e8d-a070-98749d6aa34e)
