### PR TITLE
Don't change output folder and store backups as zip 

### DIFF
--- a/plugins/thread.py
+++ b/plugins/thread.py
@@ -102,20 +102,22 @@ class ProcessThread(Thread):
 
         # make output dir
         filename = os.path.splitext(os.path.basename(self.process_manager.board.GetFileName()))[0]
-        name = ProcessManager.normalize_filename("_".join(("{} {} {}".format(title or filename, revision or '', timestamp).strip()).split()))
-        output_path = os.path.join(project_directory, outputFolder, name)
-        os.makedirs(output_path)
-
+        output_path = os.path.join(project_directory, outputFolder)
+        if not os.path.exists(output_path):
+            os.makedirs(output_path)
+        
         # rename gerber archive
         gerberArchiveName = ProcessManager.normalize_filename("_".join(("{} {}".format(title or filename, revision or '').strip() + '.zip').split()))
         os.rename(temp_file, os.path.join(temp_dir, gerberArchiveName))
 
+
+        backup_name = ProcessManager.normalize_filename("_".join(("{} {} {}".format(title or filename, revision or '', timestamp).strip()).split()))
+        shutil.make_archive(os.path.join(output_path, 'backups', backup_name), 'zip', temp_dir)
+
+
         # copy to & open output dir
         try:
-            if os.path.exists(output_path):
-                shutil.rmtree(output_path)
-
-            shutil.copytree(temp_dir, output_path)
+            shutil.copytree(temp_dir, output_path, dirs_exist_ok=True)
             webbrowser.open("file://%s" % (output_path))
             shutil.rmtree(temp_dir)
         except Exception as e: 

--- a/plugins/thread.py
+++ b/plugins/thread.py
@@ -25,11 +25,9 @@ class ProcessThread(Thread):
         # initializing
         self.progress(0)
 
-        timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H-%M-%S')
-
-        temp_dir = tempfile.mkdtemp() + timestamp
-        os.makedirs(temp_dir)
-        os.makedirs(temp_dir + "_g")
+        temp_dir = tempfile.mkdtemp()
+        temp_dir_gerber = temp_dir + "_g"
+        os.makedirs(temp_dir_gerber)
 
         _, temp_file = tempfile.mkstemp()
         project_directory = os.path.dirname(self.process_manager.board.GetFileName())
@@ -41,11 +39,11 @@ class ProcessThread(Thread):
 
             # generate gerber
             self.progress(20)
-            self.process_manager.generate_gerber(temp_dir + "_g")
+            self.process_manager.generate_gerber(temp_dir_gerber)
 
             # generate drill file
             self.progress(30)
-            self.process_manager.generate_drills(temp_dir + "_g")
+            self.process_manager.generate_drills(temp_dir_gerber)
 
             # generate netlist
             self.progress(40)
@@ -65,9 +63,9 @@ class ProcessThread(Thread):
 
             # generate production archive
             self.progress(85)
-            temp_file = self.process_manager.generate_archive(temp_dir + "_g", temp_file)
+            temp_file = self.process_manager.generate_archive(temp_dir_gerber, temp_file)
             shutil.move(temp_file, temp_dir)
-            shutil.rmtree(temp_dir + "_g")
+            shutil.rmtree(temp_dir_gerber)
             temp_file = os.path.join(temp_dir, os.path.basename(temp_file))
         except Exception as e:
             wx.MessageBox(str(e), "Error", wx.OK | wx.ICON_ERROR)
@@ -110,7 +108,7 @@ class ProcessThread(Thread):
         gerberArchiveName = ProcessManager.normalize_filename("_".join(("{} {}".format(title or filename, revision or '').strip() + '.zip').split()))
         os.rename(temp_file, os.path.join(temp_dir, gerberArchiveName))
 
-
+        timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H-%M-%S')
         backup_name = ProcessManager.normalize_filename("_".join(("{} {} {}".format(title or filename, revision or '', timestamp).strip()).split()))
         shutil.make_archive(os.path.join(output_path, 'backups', backup_name), 'zip', temp_dir)
 


### PR DESCRIPTION
**Store backups as zip instead of new directories. This makes it easier when uploading files in the browser, so that we don't have to keep switching folders and finding were latest production files are. 
Zips are still stored with a timestamp in `backups` subfolder.**

Also fixes orphaned temporary folders in system temp directory. The timestamp in temp folders was probably added for debugging, but original temp folder was never removed.  Fixed by removing the timestamp from temp folders. 