### PR TITLE
Consistent top/bottom offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Select 'Exclude from position files' or 'Exclude from BOM' in the footprint's fa
 ---
 
 ### ③ Offset Component Rotation
-The rotation of components in KiCad Footprints does not always match the orientation in the JLC library because KiCad and JLC PCB used different variation of the same standard. Most of the rotations may be corrected by the `rotations.cf` definitions. To the exception cases: add an 'JLCPCB Rotation Offset' field with an counter-clockwise orientation offset in degrees to correct this.
+The rotation of components in KiCad Footprints does not always match the orientation in the JLC library because KiCad and JLC PCB used different variation of the same standard. Most of the rotations may be corrected by the `rotations.cf` definitions. To the exception cases: add an 'JLCPCB Rotation Offset' field - with positive values indicating counter-clockwise orientation offset in degrees.
 
 <img src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/blob/master/assets/rotation-jlc.png?raw=true" height=164>
 
@@ -91,7 +91,20 @@ _The fields will be queried in the order denoted above._
 ---
 
 ### ④ Offset Component Position
-The position of components in KiCad Footprints does not always match the orientation in the JLC library because KiCad and JLCPB used different variation of the same standard. To the exception cases: add an 'JLCPCB Position Offset' field with an comma seperated x,y position offset to correct it.
+The position of components in KiCad Footprints does not always match the orientation in the JLC library because KiCad and JLCPB used different variation of the same standard. To the exception cases: add an 'JLCPCB Position Offset' field with an comma separated x,y position offset to correct it. 
+
+Use following table to quickly find out to which coordinate enter the correction based on JLC arrows clicks - depending on footprint rotation in Kicad PCB Editor status bar:
+|Kicad footprint deg | x | y|
+|----|----|----|
+|0deg, Front | right arrow | up arrow |
+|0deg, Back | left arrow | down arrow |
+|180deg, Front | left arrow | down arrow |
+|180deg, Back | right arrow | up arrow |
+|90deg, Front or Back | up arrow | left arrow |
+|-90deg, Front or Back | down arrow | right arrow |
+
+For custom angles it's best to place also a temporary straight symbol to perform alignment.
+Single arrow press in JLC is about 0.07mm shift (8 clicks is about 0.5mm).
 
 <img src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/blob/master/assets/position.png?raw=true" height=420>
 

--- a/plugins/process.py
+++ b/plugins/process.py
@@ -190,19 +190,22 @@ class ProcessManager:
                 # Get the rotation offset to be added to the actual rotation prioritizing the explicated by the
                 # designer at the standards symbol fields. If not specified use the internal database.
                 rotation_offset = self._get_rotation_offset_from_footprint(footprint) #or self._get_rotation_from_db(footprint)
-                rotation = (rotation + rotation_offset) % 360.0
 
                 # position offset needs to take rotation into account
                 pos_offset = self._get_position_offset_from_footprint(footprint)
                 rsin = math.sin(rotation / 180 * math.pi)
                 rcos = math.cos(rotation / 180 * math.pi)
-                pos_offset = ( pos_offset[0] * rcos - pos_offset[1] * rsin, pos_offset[0] * rsin + pos_offset[1] * rcos )
+                if layer == 'bottom':
+                    pos_offset = ( pos_offset[0] * rcos + pos_offset[1] * rsin, pos_offset[0] * rsin - pos_offset[1] * rcos )
+                else:
+                    pos_offset = ( pos_offset[0] * rcos - pos_offset[1] * rsin, pos_offset[0] * rsin + pos_offset[1] * rcos )
                 mid_x, mid_y = tuple(map(sum,zip((mid_x, mid_y), pos_offset)))
 
                 # JLC expect 'Rotation' to be 'as viewed from above component', so bottom needs inverting, and ends up 180 degrees out as well
                 if layer == 'bottom':
-                    rotation = (540.0 - rotation) % 360.0
-                                
+                    rotation = (180.0 - rotation)
+                rotation = (rotation + rotation_offset) % 360.0
+
                 self.components.append({
                     'Designator': designator,
                     'Mid X': mid_x,


### PR DESCRIPTION
Single offset for a given footprint will be applied correctly to all footprint (with different rotations and board side). 
![image](https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/841061/438e22bc-72e5-4452-95f7-8693617d0d53)
No more `--mixed values--` depending on top/bottom PCB placement. Fixes #101.

Following [example.zip](https://github.com/bennymeg/JLC-Plugin-for-KiCad/files/13932469/test.zip) contains some extra offsets added to footprints. 

Top/bottom without this PR:
<img src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/841061/f6cdb59b-d96a-49ec-94bc-29c737e237ca" width="400"/><img src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/841061/197223ab-b3fd-47d8-89b7-30a1cd930268" width="400"/>
Top/bottom with the PR:
<img src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/841061/0ca0d8a4-0513-49cd-92b7-d7fca2c9f07e" width="400"/><img src="https://github.com/bennymeg/JLC-Plugin-for-KiCad/assets/841061/945dc8f6-502b-4ef1-ae1e-41b4e7cbb18f" width="400"/>

Notes: 
- USB-C and diodes have artificial offset added to the footprint.  Notice that top diodes offsets are the same after PR.  However USB-C position offset has changed after PR. This is because position offset should be applied without rotation offset (it depends only on footprint orientation and not final part orientation). And, unlike diodes, USB-C has a rotation offset.
- QFN and DFN chips and diodes are only correct on both side of the board with the PR
- SOT23 transistors are correct even before the PR, because 180deg correction accidentally worked on both sides the same
- if one wants to replicate this example, ignore J5, J6 for now, they are centered correctly for me because I am modified anchor calculation locally for now