### PR TITLE
Use IsDNP() to get the DNP attribute in KiCAD v8

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -150,7 +150,9 @@ class ProcessManager:
             #     2: 'unspecified'
             # }.get(footprint.GetAttributes())
 
-            skip_footprint = exclude_dnp and (footprint_has_field(footprint, 'dnp') or footprint.GetValue().upper() == 'DNP')
+            skip_footprint = exclude_dnp and (footprint_has_field(footprint, 'dnp')
+                                              or footprint.GetValue().upper() == 'DNP'
+                                              or getattr(footprint, 'IsDNP', bool)())
 
             if not (footprint.GetAttributes() & pcbnew.FP_EXCLUDE_FROM_POS_FILES) and not skip_footprint:
                 # append unique ID if duplicate footprint designator


### PR DESCRIPTION
`footprint_has_field(footprint, 'dnp')` returns `False` for DNP components in KiCAD v8.

In KiCAD v8 the DNP flag is available via either the IsDNP() getter or the FP_DNP attribute.

The added `getattr()` call turns into `footprint.IsDNP()` in KiCAD v8 or `bool()` (which evaluates into `False`) in KiCAD v7 and earlier.