### PR TITLE
Footprints without pads fix #133

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -155,11 +155,15 @@ class ProcessManager:
             #     2: 'unspecified'
             # }.get(footprint.GetAttributes())
 
-            skip_footprint = exclude_dnp and (footprint_has_field(footprint, 'dnp')
-                                              or footprint.GetValue().upper() == 'DNP'
-                                              or getattr(footprint, 'IsDNP', bool)())
+            skip_footprint = ((footprint.GetAttributes() & pcbnew.FP_EXCLUDE_FROM_POS_FILES)
+                                or footprint.GetPadCount() == 0
+                                or exclude_dnp
+                                    and (footprint_has_field(footprint, 'dnp')
+                                        or (footprint.GetValue().upper() == 'DNP')
+                                        or getattr(footprint, 'IsDNP', bool))
+            )
 
-            if not (footprint.GetAttributes() & pcbnew.FP_EXCLUDE_FROM_POS_FILES) and not skip_footprint:
+            if not skip_footprint:
                 # append unique ID if duplicate footprint designator
                 unique_id = ""
                 if footprint_designators[footprint.GetReference()] > 1:

--- a/plugins/process.py
+++ b/plugins/process.py
@@ -112,11 +112,13 @@ class ProcessManager:
             return footprint.GetPosition()
         if footprint.GetAttributes() & pcbnew.FP_THROUGH_HOLE:
             return footprint.GetBoundingBox(False, False).GetCenter()
+
+        # handle Unspecified footprint type
         pads = footprint.Pads()
-        #get bounding box based on pads only to ignore non-copper layers, e.g. silkscreen
-        bbox = pads[0].GetBoundingBox()
+        # get bounding box based on pads only to ignore non-copper layers, e.g. silkscreen
+        bbox = pads[0].GetBoundingBox() # start with small bounding box
         for pad in pads:
-            bbox.Merge(pad.GetBoundingBox())
+            bbox.Merge(pad.GetBoundingBox()) # expand bounding box
         return bbox.GetCenter()
 
     def generate_tables(self, temp_dir, auto_translate, exclude_dnp):


### PR DESCRIPTION
Graphics can be stored as footprints - usually with `Unspecified` footprint type. That triggered footprint position calculation based on [pads bounding box centroid](https://github.com/bennymeg/JLC-Plugin-for-KiCad/pull/117) (intended weird footprints imported from other programs, not for graphics).  Graphics don't have pads which was causing Index out of range error. 

Changes:
- skipping footprint without pads - fixes #133
- small refactor (put all skipping conditions in `skip_footprint` var)
- added extra comments (because I was getting confused about my own code).