### PR TITLE
fix #140: adjusting plot options and drill options to more closely match JLCPCB recommendations

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -59,9 +59,10 @@ class ProcessManager:
         plot_options.SetScale(1)
         plot_options.SetMirror(False)
         plot_options.SetUseGerberAttributes(True)
-        plot_options.SetUseGerberProtelExtensions(False)
+        plot_options.SetUseGerberProtelExtensions(True)
         plot_options.SetUseAuxOrigin(True)
         plot_options.SetSubtractMaskFromSilk(True)
+        plot_options.SetUseGerberX2format(False)
         plot_options.SetDrillMarksType(0)  # NO_DRILL_SHAPE
         
         if hasattr(plot_options, "SetExcludeEdgeLayer"):
@@ -95,11 +96,12 @@ class ProcessManager:
 
         drill_writer.SetOptions(
             False,
-            True,
+            False,
             self.board.GetDesignSettings().GetAuxOrigin(),
             False)
-        drill_writer.SetFormat(False)
-        drill_writer.CreateDrillandMapFilesSet(temp_dir, True, False)
+        drill_writer.SetFormat(True)
+        drill_writer.SetMapFileFormat(pcbnew.PLOT_FORMAT_GERBER)
+        drill_writer.CreateDrillandMapFilesSet(temp_dir, True, True)
 
     def generate_netlist(self, temp_dir):
         '''Generate the connection netlist.'''


### PR DESCRIPTION
The following plot settings are changed to closely match [JLCPCB recommendations](https://jlcpcb.com/help/article/362-how-to-generate-gerber-and-drill-files-in-kicad-7):
- Protel extensions are being used
- Gerber X2 format is explicitly set to false - [caused issues in the past](https://forum.kicad.info/t/apologies-from-atommann-an-engineer-from-jlcpcb-about-gerber-x2-files-at-jlcpcb/26847), even though it might be supported nowadays

Drill settings changed:
- "minimal header" set to false (via `SetOptions`)
- drill units set to "metric" (via `SetFormat(True)`)
- drill map files are being generated and their format is set to Gerber

This fixes #140 