### PR TITLE
Fix noBackup CLI option

### DIFF
--- a/plugins/cli.py
+++ b/plugins/cli.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     options[ALL_ACTIVE_LAYERS_OPT] = args.allActiveLayers
     options[ARCHIVE_NAME] = args.archiveName
     options[EXTRA_LAYERS] = args.additionalLayers
-    options[NO_BACKUP_OPT] = args.no_backup
+    options[NO_BACKUP_OPT] = args.noBackup
     
     openBrowser = args.openBrowser
     nonInteractive = args.nonInteractive


### PR DESCRIPTION
I have no idea how this slipped into the PR that got merged, but there's a mistake in the processing of the noBackup CLI option that causes an error when used 😔

This PR fixes the typo. Confirmed working running locally:

```
python3 -m com_github_bennymeg_JLC-Plugin-for-KiCad.cli --noBackup -p Test.kicad_pcb
./kicad/pcbnew/action_plugin.cpp(163): assert "PgmOrNull()" failed in register_action().
12:40:19: Debug: Adding duplicate image handler for 'PNG file'
12:40:19: Debug: Adding duplicate image handler for 'JPEG file'
12:40:19: Debug: Adding duplicate image handler for 'TIFF file'
12:40:19: Debug: Adding duplicate image handler for 'GIF file'
12:40:19: Debug: Adding duplicate image handler for 'PNM file'
12:40:19: Debug: Adding duplicate image handler for 'PCX file'
12:40:19: Debug: Adding duplicate image handler for 'IFF file'
12:40:19: Debug: Adding duplicate image handler for 'Windows icon file'
12:40:19: Debug: Adding duplicate image handler for 'Windows cursor file'
12:40:19: Debug: Adding duplicate image handler for 'Windows animated cursor file'
12:40:19: Debug: Adding duplicate image handler for 'TGA file'
12:40:19: Debug: Adding duplicate image handler for 'XPM file'
Progress: |██████████████████████████████████████████████████| 100.00% Complete
```

Result:

<img width="443" height="306" alt="image" src="https://github.com/user-attachments/assets/9b5d991d-89e1-424f-86ba-f29328fd377d" />
