### PR TITLE
Fix crash when trying to rename non-existent files

### DIFF
--- a/plugins/thread.py
+++ b/plugins/thread.py
@@ -162,9 +162,12 @@ class ProcessThread(Thread):
         os.rename(temp_file, os.path.join(temp_dir, gerberArchiveName))
 
         if self.options[ARCHIVE_NAME]:
-            os.rename(os.path.join(temp_dir, designatorsFileName), os.path.join(temp_dir, ProcessManager.normalize_filename("_".join((baseName.strip() + '_designators.csv').split()))))
-            os.rename(os.path.join(temp_dir, placementFileName), os.path.join(temp_dir, ProcessManager.normalize_filename("_".join((baseName.strip() + '_positions.csv').split()))))
-            os.rename(os.path.join(temp_dir, bomFileName), os.path.join(temp_dir, ProcessManager.normalize_filename("_".join((baseName.strip() + '_bom.csv').split()))))
+            if os.path.exists(os.path.join(temp_dir, designatorsFileName)):
+                os.rename(os.path.join(temp_dir, designatorsFileName), os.path.join(temp_dir, ProcessManager.normalize_filename("_".join((baseName.strip() + '_designators.csv').split()))))
+            if os.path.exists(os.path.join(temp_dir, placementFileName)):
+                os.rename(os.path.join(temp_dir, placementFileName), os.path.join(temp_dir, ProcessManager.normalize_filename("_".join((baseName.strip() + '_positions.csv').split()))))
+            if os.path.exists(os.path.join(temp_dir, bomFileName)):
+                os.rename(os.path.join(temp_dir, bomFileName), os.path.join(temp_dir, ProcessManager.normalize_filename("_".join((baseName.strip() + '_bom.csv').split()))))
 
         # Make a backup as long as the NO_BACKUP_OPT flag isn't set.
         if not self.options[NO_BACKUP_OPT]:


### PR DESCRIPTION
As the title says, this fixes a crash when the designators/BOM/positions files were not generated (e.g. because there are no footprints to place/they are all excluded from the BOM/positions file)