### PR TITLE
Update for Kicad 10.0

### DIFF
--- a/plugins/process.py
+++ b/plugins/process.py
@@ -131,8 +131,12 @@ class ProcessManager:
 
         # if the footprint is not rotated by a multiple of 90 degrees, the bounding boxes will be off, so we create a temporary copy that is rotated to 0
         if footprint_rotated:
-            footprint = footprint.Duplicate()
-            footprint.SetOrientationDegrees(0)
+            dup = footprint.Duplicate(False)
+            footprint = pcbnew.Cast_to_FOOTPRINT(dup) if hasattr(pcbnew, 'Cast_to_FOOTPRINT') else dup
+            if hasattr(footprint, 'SetOrientationDegrees'):
+                footprint.SetOrientationDegrees(0)
+            else:
+                footprint.SetOrientation(pcbnew.EDA_ANGLE(0, pcbnew.DEGREES_T))
 
         if origin_type == 'Anchor':
             position = footprint.GetPosition()

--- a/plugins/process.py
+++ b/plugins/process.py
@@ -131,7 +131,12 @@ class ProcessManager:
 
         # if the footprint is not rotated by a multiple of 90 degrees, the bounding boxes will be off, so we create a temporary copy that is rotated to 0
         if footprint_rotated:
-            dup = footprint.Duplicate(False)
+            try:
+                # kicad 10 
+                dup = footprint.Duplicate(False)
+            except TypeError:
+                # fallback for kicad <10 
+                dup = footprint.Duplicate()
             footprint = pcbnew.Cast_to_FOOTPRINT(dup) if hasattr(pcbnew, 'Cast_to_FOOTPRINT') else dup
             if hasattr(footprint, 'SetOrientationDegrees'):
                 footprint.SetOrientationDegrees(0)


### PR DESCRIPTION
<img width="600" height="982" alt="Screenshot 2026-03-25 at 23 03 33" src="https://github.com/user-attachments/assets/910306d1-b933-4961-8d5c-ca2075c62438" />
<img width="600" height="982" alt="Screenshot 2026-03-25 at 22 57 45" src="https://github.com/user-attachments/assets/f46fa280-215a-4a83-b59e-b6bb8825010b" />

fixes plugin crashes on kicad 10 & still works on kicad 9