### PR TITLE
Fix KiCad 10 footprint cast — Cast_to_FOOTPRINT was removed

### DIFF
--- a/plugins/utils.py
+++ b/plugins/utils.py
@@ -25,12 +25,19 @@ def is_v6(version = get_version()):
 def duplicate_footprint(footprint):
     version = get_version()
 
-    if is_v10(version): 
+    if is_v10(version):
         duplicate = footprint.Duplicate(False)
     else:
         duplicate = footprint.Duplicate()
-    
-    return pcbnew.Cast_to_FOOTPRINT(duplicate) if hasattr(pcbnew, 'Cast_to_FOOTPRINT') else duplicate
+
+    # KiCad 10 SWIG returns the base BOARD_ITEM and removed the
+    # pcbnew.Cast_to_FOOTPRINT helper; downcast via the object's own
+    # .Cast() method instead. Older KiCads still ship Cast_to_FOOTPRINT.
+    if hasattr(pcbnew, 'Cast_to_FOOTPRINT'):
+        return pcbnew.Cast_to_FOOTPRINT(duplicate)
+    if hasattr(duplicate, 'Cast'):
+        return duplicate.Cast()
+    return duplicate
 
 def footprint_to_degrees(footprint):
     if hasattr(footprint, 'SetOrientationDegrees'):


### PR DESCRIPTION
The existing duplicate_footprint() already handles KiCad 10's Duplicate(addToParentGroup) signature, but the cast back to FOOTPRINT afterward still relies on pcbnew.Cast_to_FOOTPRINT(). That helper was removed in KiCad 10 in favor of a .Cast() method on the returned BOARD_ITEM object. Without the cast, downstream calls like SetOrientationDegrees() fail with 'BOARD_ITEM' object has no attribute 'SetOrientationDegrees' whenever a footprint is rotated to a non-multiple-of-90-degrees angle (common case: an inter-panel solder strip aligned to a slant edge).
 
This PR adds .Cast() as a fallback for KiCad 10+, while preserving the existing Cast_to_FOOTPRINT path for older versions.
Repro on KiCad 10: any board with a footprint at e.g. 80° rotation triggers the error during plugin run.
Verified on: KiCad 10.0, board with WS2812B-based design where 6 inter-panel solder strips are placed at +/-80° rotations.