### PR TITLE
fix: use loaded board in expandTextVariables for CLI mode

### DIFF
--- a/plugins/thread.py
+++ b/plugins/thread.py
@@ -41,8 +41,9 @@ class ProcessThread(Thread):
         self.start()
 
     def expandTextVariables(self, string):
-        titleBlock = pcbnew.GetBoard().GetTitleBlock()
-        
+        board = self.board if self.board is not None else pcbnew.GetBoard()
+        titleBlock = board.GetTitleBlock()
+
         titleBlockVars = {
             "ISSUE_DATE": titleBlock.GetDate(),
             "CURRENT_DATE": datetime.datetime.now().strftime('%Y-%m-%d'),


### PR DESCRIPTION
Fixes #217.

In CLI mode the plugin loads the board explicitly via `pcbnew.LoadBoard(cli)` and stores it on `self.board`. `expandTextVariables` was calling `pcbnew.GetBoard()` which returns `None` outside the KiCad GUI, causing `AttributeError: 'NoneType' object has no attribute 'GetTitleBlock'` when `--archiveName` is passed.

Use `self.board` when set, falling back to `pcbnew.GetBoard()` for the GUI path.